### PR TITLE
Add parallel number printing with 4 threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # c-intro
 Files of course C
+
+## Parallel Number Printer
+A new program has been added to demonstrate printing numbers from 0 to 100 in parallel using 4 threads. The program is located in `threads/print_parallel.c`.
+
+### Compilation and Execution
+To compile the program, navigate to the `threads` directory and run the following command:
+```
+gcc -pthread print_parallel.c -o print_parallel
+```
+To execute the program, simply run:
+```
+./print_parallel
+```
+This will print numbers from 0 to 100 in parallel, with each thread handling a unique quarter of the range.

--- a/threads/print_parallel.c
+++ b/threads/print_parallel.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#define NUM_THREADS 4
+#define RANGE 100
+
+pthread_mutex_t lock;
+
+void *print_range(void *arg) {
+    int thread_part = *((int *)arg);
+
+    int start = thread_part * (RANGE / NUM_THREADS);
+    int end = (thread_part + 1) * (RANGE / NUM_THREADS);
+
+    for (int i = start; i < end; i++) {
+        pthread_mutex_lock(&lock);
+        printf("%d ", i);
+        pthread_mutex_unlock(&lock);
+    }
+
+    return NULL;
+}
+
+int main() {
+    pthread_t threads[NUM_THREADS];
+    int thread_args[NUM_THREADS];
+
+    if (pthread_mutex_init(&lock, NULL) != 0) {
+        printf("\n mutex init has failed\n");
+        return 1;
+    }
+
+    for (int i = 0; i < NUM_THREADS; i++) {
+        thread_args[i] = i;
+        if (pthread_create(&threads[i], NULL, print_range, (void *)&thread_args[i]) != 0) {
+            printf("Failed to create thread\n");
+        }
+    }
+
+    for (int i = 0; i < NUM_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    pthread_mutex_destroy(&lock);
+
+    return 0;
+}


### PR DESCRIPTION
Adds a new C program to the `mario21ic/c-demos` repository that demonstrates printing numbers from 0 to 100 in parallel using 4 threads, and updates the README.md with instructions for compiling and running the new program.

- **New Program Implementation**: Adds `threads/print_parallel.c`, which divides the task of printing numbers from 0 to 100 into four equal parts, with each part assigned to a separate thread. Utilizes mutexes to manage access to the printing function, ensuring thread-safe output.
- **README.md Update**: Enhances the documentation by adding a section on the new `Parallel Number Printer` program, including compilation and execution instructions, and explaining the program's purpose and functionality.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mario21ic/c-demos?shareId=3472446d-374d-49ae-a7e6-466faf4017cc).